### PR TITLE
fix(IPluginAuth): adduser, changePassword optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -450,8 +450,8 @@ type StringValue = string | void | null;
 	interface IPluginAuth<T> extends IPlugin<T> {
 		login_url?: string;
 		authenticate(user: string, password: string, cb: Callback): void;
-		adduser(user: string, password: string, cb: Callback): void;
-		changePassword(user: string, password: string, newPassword: string, cb: Callback): void;
+		adduser?(user: string, password: string, cb: Callback): void;
+		changePassword?(user: string, password: string, newPassword: string, cb: Callback): void;
 		allow_access?(user: RemoteUser, pkg: T & PackageAccess, cb: Callback): void;
 		allow_publish?(user: RemoteUser, pkg: T & PackageAccess, cb: Callback): void;
 	}


### PR DESCRIPTION
Even though it might not be immediately apparent from the source code, the methods `adduser` (or `add_user`) and `changePassword` are indeed optional.

changePassword: https://github.com/verdaccio/verdaccio/blob/66f4197236d9d71af149314aae15102b336f45e1/src/lib/auth.ts#L67-L71
adduser: https://github.com/verdaccio/verdaccio/blob/66f4197236d9d71af149314aae15102b336f45e1/src/lib/auth.ts#L138-L166

The official docs also agree with this.
https://verdaccio.org/docs/en/dev-plugins#authentication-plugin